### PR TITLE
Remove warning on newer modmenu versions

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -26,10 +26,7 @@
     "minecraft": ">=1.16.2"
   },
   "recommends": {
-    "modmenu": ">=1.14.6"
-  },
-  "custom": {
-    "modmenu:clientsideOnly": true
+    "modmenu": ">=1.16.3"
   },
   "accessWidener" : "betterf3.accesswidener"
 }


### PR DESCRIPTION
Fixes warning with Modmenu 1.16.0 and above.