### PR TITLE
+ Hide Sidebar option for F3 Mode

### DIFF
--- a/common/src/main/java/me/cominixo/betterf3/config/GeneralOptions.java
+++ b/common/src/main/java/me/cominixo/betterf3/config/GeneralOptions.java
@@ -37,4 +37,8 @@ public final class GeneralOptions {
    * Sets the background color.
    */
   public static int backgroundColor = 0x6F505050;
+  /**
+   * Hides the sidebar while looking at F3.
+   */
+  public static boolean hideSidebar = true;
 }

--- a/common/src/main/java/me/cominixo/betterf3/config/ModConfigFile.java
+++ b/common/src/main/java/me/cominixo/betterf3/config/ModConfigFile.java
@@ -42,6 +42,7 @@ public final class ModConfigFile {
     general.set("animationSpeed", GeneralOptions.animationSpeed);
     general.set("fontScale", GeneralOptions.fontScale);
     general.set("background_color", GeneralOptions.backgroundColor);
+    general.set("hide_sidebar", GeneralOptions.hideSidebar);
 
     final List<Config> configsLeft = new ArrayList<>();
 
@@ -230,6 +231,7 @@ public final class ModConfigFile {
       GeneralOptions.animationSpeed = general.getOrElse("animationSpeed", 1.0);
       GeneralOptions.fontScale = general.getOrElse("fontScale", 1.0);
       GeneralOptions.backgroundColor = general.getOrElse("background_color", 0x6F505050);
+      GeneralOptions.hideSidebar = general.getOrElse("hide_sidebar", true);
     }
 
     config.close();

--- a/common/src/main/java/me/cominixo/betterf3/config/gui/GeneralOptionsScreen.java
+++ b/common/src/main/java/me/cominixo/betterf3/config/gui/GeneralOptionsScreen.java
@@ -80,6 +80,12 @@ public final class GeneralOptionsScreen {
     .setSaveConsumer(newValue -> GeneralOptions.backgroundColor = newValue)
     .build());
 
+    general.addEntry(entryBuilder.startBooleanToggle(new TranslatableText("config.betterf3.sidebar"), GeneralOptions.hideSidebar)
+    .setDefaultValue(true)
+    .setTooltip(new TranslatableText("config.betterf3.sidebar.tooltip"))
+    .setSaveConsumer(newValue -> GeneralOptions.hideSidebar = newValue)
+    .build());
+
     builder.transparentBackground();
     return builder;
   }

--- a/common/src/main/java/me/cominixo/betterf3/mixin/scoreboard/ScoreboardMixin.java
+++ b/common/src/main/java/me/cominixo/betterf3/mixin/scoreboard/ScoreboardMixin.java
@@ -1,0 +1,34 @@
+package me.cominixo.betterf3.mixin.scoreboard;
+
+import me.cominixo.betterf3.config.GeneralOptions;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.hud.InGameHud;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Mixin to cancel sidebar rendering during F3.
+ */
+@Mixin(InGameHud.class)
+public class ScoreboardMixin {
+
+  @Shadow @Final private MinecraftClient client;
+
+  /**
+   * Cancels sidebar rendering during F3 if the hideSidebar setting is true.
+   *
+   * @param info Callback info
+   */
+  @Inject(at = @At("HEAD"), method = "renderScoreboardSidebar", cancellable = true)
+  public void init(final CallbackInfo info) {
+    if (GeneralOptions.hideSidebar) {
+      if (this.client.options.debugEnabled) {
+        info.cancel();
+      }
+    }
+  }
+}

--- a/common/src/main/java/me/cominixo/betterf3/mixin/scoreboard/package-info.java
+++ b/common/src/main/java/me/cominixo/betterf3/mixin/scoreboard/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Scoreboard related mixins.
+ */
+package me.cominixo.betterf3.mixin.scoreboard;

--- a/common/src/main/resources/assets/betterf3/lang/en_us.json
+++ b/common/src/main/resources/assets/betterf3/lang/en_us.json
@@ -23,6 +23,8 @@
   "config.betterf3.animations.tooltip": "Add an animation when closing and opening the F3 HUD.",
   "config.betterf3.animationSpeed": "Animation Speed",
   "config.betterf3.animationSpeed.tooltip": "Set the speed of the animation.",
+  "config.betterf3.sidebar": "Hide Sidebar",
+  "config.betterf3.sidebar.tooltip": "Hide sidebar during F3.",
   "config.betterf3.fontScale": "Font Scale",
   "config.betterf3.fontScale.tooltip": "Set the scale of the font.",
   "config.betterf3.category.modules": "Modules",

--- a/common/src/main/resources/betterf3.mixins.json
+++ b/common/src/main/resources/betterf3.mixins.json
@@ -8,6 +8,7 @@
     "KeyboardMixin",
     "chunk.ChunkBuilderMixin",
     "chunk.ClientChunkMapMixin",
-    "chunk.ClientChunkManagerMixin"
+    "chunk.ClientChunkManagerMixin",
+    "scoreboard.ScoreboardMixin"
   ]
 }


### PR DESCRIPTION
Hello! I added a very useful option for the F3 Mode. 🧰 
As soon as you press F3, the sidebar rendering is cancelled so that you can easily read your debug information.
Here is how it works: 🔨 
![Animation](https://user-images.githubusercontent.com/38810661/170056055-e696f449-7bed-48b9-84a3-b7fc4b252f0c.gif)


The code style was checked and everything is fine. (No errors, everything is compatible)
Note: I did not change or modify any version numbers, I leave that up to the project owner 😃 

Have a great day! ❤️ 